### PR TITLE
core: Clipboard component

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -2,8 +2,9 @@ add_definitions(-DQT_PLUGIN)
 
 set(SOURCES
     plugin.cpp
-    standardpaths.cpp
+    clipboard.cpp
     device.cpp
+    standardpaths.cpp
 )
 
 add_library(fluidcore SHARED ${SOURCES})

--- a/core/clipboard.cpp
+++ b/core/clipboard.cpp
@@ -1,0 +1,33 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "clipboard.h"
+
+#include <QGuiApplication>
+
+Clipboard::Clipboard(QObject *parent) : QObject(parent), m_clipboard(QGuiApplication::clipboard())
+{
+    connect(m_clipboard, &QClipboard::dataChanged, this, &Clipboard::textChanged);
+}
+
+QString Clipboard::text() const
+{
+    return m_clipboard->text();
+}
+
+void Clipboard::clear()
+{
+    m_clipboard->clear();
+}
+
+void Clipboard::setText(const QString &text)
+{
+    m_clipboard->setText(text);
+}

--- a/core/clipboard.h
+++ b/core/clipboard.h
@@ -1,0 +1,37 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QClipboard>
+
+class Clipboard : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
+
+public:
+    explicit Clipboard(QObject *parent = nullptr);
+
+    QString text() const;
+
+    Q_INVOKABLE void clear();
+
+public Q_SLOTS:
+    void setText(const QString &text);
+
+Q_SIGNALS:
+    void textChanged();
+
+private:
+    QClipboard *m_clipboard = nullptr;
+};

--- a/core/plugin.cpp
+++ b/core/plugin.cpp
@@ -27,16 +27,9 @@
 #include <QtQml/qqml.h>
 #include <QtQml/QQmlExtensionPlugin>
 
-#include "standardpaths.h"
+#include "clipboard.h"
 #include "device.h"
-
-static QObject *standardPathsProvider(QQmlEngine *engine, QJSEngine *jsEngine)
-{
-    Q_UNUSED(engine);
-    Q_UNUSED(jsEngine);
-
-    return new StandardPaths();
-}
+#include "standardpaths.h"
 
 static QObject *deviceProvider(QQmlEngine *engine, QJSEngine *jsEngine)
 {
@@ -44,6 +37,14 @@ static QObject *deviceProvider(QQmlEngine *engine, QJSEngine *jsEngine)
     Q_UNUSED(jsEngine);
 
     return new Device();
+}
+
+static QObject *standardPathsProvider(QQmlEngine *engine, QJSEngine *jsEngine)
+{
+    Q_UNUSED(engine);
+    Q_UNUSED(jsEngine);
+
+    return new StandardPaths();
 }
 
 class FluidCorePlugin : public QQmlExtensionPlugin
@@ -59,10 +60,11 @@ void FluidCorePlugin::registerTypes(const char *uri)
     Q_ASSERT(QByteArray("Fluid.Core") == QByteArray(uri));
 
     // @uri Fluid.Core
-    qmlRegisterSingletonType<StandardPaths>(uri, 1, 0, "StandardPaths",
-                                            standardPathsProvider);
+    qmlRegisterType<Clipboard>(uri, 1, 0, "Clipboard");
     qmlRegisterSingletonType<Device>(uri, 1, 0, "Device",
                                      deviceProvider);
+    qmlRegisterSingletonType<StandardPaths>(uri, 1, 0, "StandardPaths",
+                                            standardPathsProvider);
 }
 
 #include "plugin.moc"

--- a/tests/tst_clipboard.qml
+++ b/tests/tst_clipboard.qml
@@ -1,0 +1,55 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.4
+import QtTest 1.0
+import Fluid.Core 1.0
+
+TestCase {
+    name: "ClipboardTests"
+
+    Clipboard {
+        id: clipboard
+    }
+
+    SignalSpy {
+        id: textChangedSpy
+        target: clipboard
+        signalName: "textChanged"
+    }
+
+    function test_clipboard_works() {
+        var text = "Hello World"
+
+        clipboard.text = text
+
+        compare(clipboard.text, text)
+    }
+
+    function tests_setting_text_should_fire_textChanged() {
+        clipboard.text = ""
+
+        textChangedSpy.clear()
+
+        clipboard.text = "Random Text"
+
+        compare(textChangedSpy.count, 1)
+    }
+
+    function test_clear_should_fire_textChanged() {
+        clipboard.text = "Non empty text"
+
+        textChangedSpy.clear()
+
+        clipboard.clear()
+
+        compare(textChangedSpy.count, 1)
+    }
+}

--- a/ui/Icon.qml
+++ b/ui/Icon.qml
@@ -103,7 +103,7 @@ Item {
                                 ? name
                                 : name.indexOf("/") !== -1 ? "icon://" + name
                                                            : "image://desktoptheme/" + name
-                                : undefined
+                                : ""
 
     /*!
        \qmlproperty enumeration status


### PR DESCRIPTION
Provides access to the current text on the clipboard.

This was used in the Terminal app from Papyros [here](https://github.com/papyros/terminal-app/blob/develop/src/qml/main.qml#L44) and [here](https://github.com/papyros/terminal-app/blob/develop/src/qml/SudoWarningDialog.qml#L41) to warn the user when pasting a command that uses `sudo`.
