### PR TITLE
ui: Standard application navigation stack and appbar

### DIFF
--- a/controls/Subheader.qml
+++ b/controls/Subheader.qml
@@ -1,5 +1,5 @@
 /*
- * QML Material - An application framework implementing Material Design.
+ * Fluid - QtQuick components for fluid and dynamic applications
  *
  * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
  *

--- a/core/Utils.qml
+++ b/core/Utils.qml
@@ -56,4 +56,12 @@ QtObject {
 
         return color.a > 0 && a >= 0.3
     }
+
+    function getSourceForIconName(name) {
+        return name ? name.indexOf("/") === 0 || name.indexOf("file://") === 0
+                      ? name
+                      : name.indexOf("/") !== -1 ? "icon://" + name
+                                                 : "image://desktoptheme/" + name
+                    : ""
+    }
 }

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -73,6 +73,7 @@ QString Device::iconName() const
         case TV:
             return "hardware/tv";
         case Unknown:
+        default:
             return "hardware/computer";
     }
 }

--- a/demo/SubPage.qml
+++ b/demo/SubPage.qml
@@ -1,0 +1,17 @@
+import QtQuick.Controls 2.0
+import Fluid.UI 1.0
+
+Page {
+    title: "Sub page demo"
+
+    actions: [
+        Action {
+            iconName: "action/settings"
+        }
+    ]
+
+    Label {
+        anchors.centerIn: parent
+        text: "Testing"
+    }
+}

--- a/demo/demo.qrc
+++ b/demo/demo.qrc
@@ -3,6 +3,7 @@
 
 <qresource>
 	<file>main.qml</file>
+	<file>SubPage.qml</file>
 </qresource>
 
 </RCC>

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -1,19 +1,30 @@
 import QtQuick 2.6
 import QtQuick.Controls 2.0
 import Fluid.Controls 1.0
+import Fluid.UI 1.0
 
-ApplicationWindow {
+FluidWindow {
     visible: true
 
-    ListView {
-        anchors.fill: parent
-        model: 5
-        header: Subheader {
-            text: "Header"
-        }
+    width: 600
+    height: 450
 
-        delegate: ListItem {
-            text: "List Item " + (index + 1)
+    title: "Fluid Demo"
+
+    initialPage: Page {
+        title: "List demo"
+
+        ListView {
+            anchors.fill: parent
+            model: 5
+            header: Subheader {
+                text: "Header"
+            }
+
+            delegate: ListItem {
+                text: "List Item " + (index + 1)
+                onClicked: pageStack.push(Qt.resolvedUrl('SubPage.qml'))
+            }
         }
     }
 }

--- a/ui/Action.qml
+++ b/ui/Action.qml
@@ -1,0 +1,60 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.4
+import Fluid.Core 1.0
+
+/*!
+   \qmltype Action
+   \inqmlmodule Fluid.UI 1.0
+
+   \brief Represents an action shown in an action bar, context menu, or list.
+
+   One of the most common uses of actions is displaying actions in the action bar of a page
+   using the \l Page::actions property. See the example for \l Page for more details.
+ */
+QtObject {
+    id: action
+
+    /*!
+       Set to \c false to disable the action in the UI.
+     */
+    property bool enabled: true
+
+    property string iconName
+
+    /*!
+       A URL pointing to an image to display as the icon. By default, this is
+       a special URL representing the icon named by \l iconName from the Material Design
+       icon collection or FontAwesome. The icon will be colorized using the specificed \l color,
+       unless you put ".color." in the filename, for example, "app-icon.color.svg".
+
+       \sa iconName
+       \sa Icon
+     */
+    property url iconSource: Utils.getSourceForIconName(iconName)
+
+    /*!
+       The text displayed for the action.
+     */
+    property string text
+
+    /*!
+       The tooltip displayed for the action.
+     */
+    property string tooltip
+
+    /*!
+       Set to \c false to hide the action in the UI.
+     */
+    property bool visible: true
+
+    signal triggered(var source)
+}

--- a/ui/AppBar.qml
+++ b/ui/AppBar.qml
@@ -1,0 +1,145 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Controls.Material 2.0
+import QtQuick.Layouts 1.0
+import Fluid.Core 1.0
+import Fluid.UI 1.0
+
+ToolBar {
+    id: appBar
+
+    Material.elevation: toolbar ? 0 : elevation
+    Material.theme: toolbar ? toolbar.Material.theme : Material.Light
+
+    /*!
+       The back action to display to the left of the title in the action bar.
+       When used with a page, this will pick up the page's back action, which
+       by default is a back arrow when there is a page behind the current page
+       on the page stack. However, you can customize this, for example, to show
+       a navigation drawer at the root of your app.
+
+       When using an action bar in a page, set the \l Page::backAction instead of
+       directly setting this property.
+     */
+    property Action leftAction
+
+    /*!
+       A list of actions to show in the action bar. These actions will be shown
+       anchored to the right, and will overflow if there are more than the
+       maximum number of actions as defined in \l maxActionCount.
+
+       When used with a page, the actions will be set to the page's \l Page::actions
+       property, so set that instead of changing this directly.
+     */
+    property list<Action> actions
+
+    /*!
+       The elevation of the action bar. Set to 0 if you want have a header or some
+       other view below the action bar that you want to appear as part of the action bar.
+     */
+    property int elevation: 2
+
+    /*!
+       \internal
+       The size of the left icon and the action icons.
+     */
+    property int iconSize: Device.gridUnit <= 48 ? 20 : 24
+
+    property alias leftKeyline: titleLabel.x
+
+    /*!
+       The maximum number of actions that can be displayed before they spill over
+       into a drop-down menu. When using an action bar with a page, this inherits
+       from the global \l Toolbar::maxActionCount. If you are using an action bar
+       for custom purposes outside of a toolbar, this defaults to \c 3.
+     */
+    property int maxActionCount: toolbar ? toolbar.maxActionCount : 3
+
+    /*!
+       The title displayed in the action bar. When used in a page, the title will
+       be set to the title of the page, so set the \l Page::title property instead
+       of changing this directly.
+     */
+    property alias title: titleLabel.text
+
+    property AppToolBar toolbar
+
+    height: Device.gridUnit
+
+    IconButton {
+        id: leftButton
+
+        property bool showing: leftAction && leftAction.visible
+        property int margin: (width - 24)/2
+
+        anchors {
+            verticalCenter: actionsRow.verticalCenter
+            left: parent.left
+            leftMargin: leftButton.showing ? 16 - leftButton.margin : -leftButton.width
+        }
+
+        iconSize: appBar.iconSize
+
+        iconSource: leftAction ? leftAction.iconSource : ""
+        visible: leftAction && leftAction.visible
+        enabled: leftAction && leftAction.enabled
+        onClicked: {
+            if (leftAction)
+                leftAction.triggered(leftButton)
+        }
+    }
+
+    Label {
+        id: titleLabel
+
+        anchors {
+            verticalCenter: actionsRow.verticalCenter
+            left: parent.left
+            right: actionsRow.left
+            leftMargin: 16 + (leftButton.showing ? Device.gridUnit - leftButton.margin : 0)
+            rightMargin: 16
+        }
+
+        textFormat: Text.PlainText
+        font: FluidStyle.titleFont
+        color: Material.primaryTextColor
+        elide: Text.ElideRight
+    }
+
+    Row {
+        id: actionsRow
+
+        anchors {
+            right: parent.right
+            rightMargin: 16 - leftButton.margin
+        }
+
+        height: appBar.height
+
+        spacing: 24 - 2 * leftButton.margin
+
+        Repeater {
+            model: appBar.actions
+            delegate: IconButton {
+                id: actionButton
+
+                iconSize: appBar.iconSize
+
+                iconSource: modelData.iconSource
+                visible: modelData.visible
+                enabled: modelData.enabled
+                onClicked: modelData.triggered(actionButton)
+            }
+        }
+    }
+}

--- a/ui/AppToolBar.qml
+++ b/ui/AppToolBar.qml
@@ -1,0 +1,53 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Controls.Material 2.0
+import Fluid.Core 1.0
+
+ToolBar {
+    id: toolbar
+
+    Material.elevation: page ? page.appBar.elevation : 2
+    Material.background: Material.primaryColor
+    Material.theme: Utils.lightDark(Material.background, Material.Light, Material.Dark)
+
+    property Page page
+    property int maxActionCount: 3
+
+    height: page ? page.appBar.height : 0
+
+    function pop(page) {
+        stack.pop(page.appBar)
+
+        toolbar.page = page
+    }
+
+    function push(page) {
+        stack.push(page.appBar)
+
+        page.appBar.toolbar = toolbar
+        toolbar.page = page
+    }
+
+    function replace(page) {
+        toolbar.page = page
+
+        stack.replace(page.appBar)
+    }
+
+    StackView {
+        id: stack
+
+        width: parent.width
+        height: parent.height
+    }
+}

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,9 +1,16 @@
 set(FLUID_FILES
     qmldir
+    Action.qml
+    AppBar.qml
+    AppToolBar.qml
     FluidStyle.qml
+    FluidWindow.qml
     Icon.qml
+    IconButton.qml
     Loadable.qml
     NoiseBackground.qml
+    Page.qml
+    PageStack.qml
     Showable.qml
     SmoothFadeImage.qml
     SmoothFadeLoader.qml

--- a/ui/FluidStyle.qml
+++ b/ui/FluidStyle.qml
@@ -19,14 +19,33 @@ QtObject {
     readonly property color iconColorLight: Qt.rgba(0,0,0,0.54)
     readonly property color iconColorDark: Qt.rgba(1,1,1)
 
-    readonly property font subheadingFont: Qt.font({ family: "Roboto",
-                                                     pointSize: Device.isMobile ? 16 : 15 })
+    readonly property font display4Font: Qt.font({ family: "Roboto", weight: Font.Light,
+                                                   pointSize: 112 })
 
-    readonly property font body1Font: Qt.font({ family: "Roboto",
-                                                pointSize: Device.isMobile ? 14 : 13 })
+    readonly property font display3Font: Qt.font({ family: "Roboto", pointSize: 56 })
+
+    readonly property font display2Font: Qt.font({ family: "Roboto", pointSize: 45 })
+
+    readonly property font display1Font: Qt.font({ family: "Roboto", pointSize: 34 })
+
+    readonly property font headlineFont: Qt.font({ family: "Roboto", pointSize: 24 })
 
     readonly property font titleFont: Qt.font({ family: "Roboto", weight: Font.DemiBold,
                                                 pointSize: 20 })
+
+    readonly property font subheadingFont: Qt.font({ family: "Roboto",
+                                                     pointSize: Device.isMobile ? 16 : 15 })
+
+    readonly property font body2Font: Qt.font({ family: "Roboto",
+                                                pointSize: Device.isMobile ? 14 : 13 })
+
+    readonly property font body1Font: Qt.font({ family: "Roboto", weight: Font.DemiBold,
+                                                pointSize: Device.isMobile ? 14 : 13 })
+
+    readonly property font captionFont: Qt.font({ family: "Roboto", pointSize: 12 })
+
+    readonly property font buttonFont: Qt.font({ family: "Roboto", weight: Font.DemiBold,
+                                                 pointSize: 14, capitalization: Font.AllUppercase })
 
     /* Control fonts that don't fit into the standard font styles */
 

--- a/ui/FluidStyle.qml
+++ b/ui/FluidStyle.qml
@@ -23,7 +23,10 @@ QtObject {
                                                      pointSize: Device.isMobile ? 16 : 15 })
 
     readonly property font body1Font: Qt.font({ family: "Roboto",
-                                                     pointSize: Device.isMobile ? 14 : 13 })
+                                                pointSize: Device.isMobile ? 14 : 13 })
+
+    readonly property font titleFont: Qt.font({ family: "Roboto", weight: Font.DemiBold,
+                                                pointSize: 20 })
 
     /* Control fonts that don't fit into the standard font styles */
 

--- a/ui/FluidWindow.qml
+++ b/ui/FluidWindow.qml
@@ -1,0 +1,80 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import Fluid.UI 1.0
+
+/*!
+   \qmltype FluidWindow
+   \inqmlmodule Fluid.UI 1.0
+
+   \brief A window that provides features commonly used for Material Design apps.
+
+   This is normally what you should use as your root component. It provides a \l Toolbar and
+   \l PageStack to provide access to standard features used by Material Design applications.
+
+   Here is a short working example of an application:
+
+   \qml
+   import QtQuick 2.4
+   import Fluid.UI 1.0
+
+   ApplicationWindow {
+       title: "Application Name"
+
+       initialPage: page
+
+       Page {
+           id: page
+           title: "Page Title"
+
+           Label {
+               anchors.centerIn: parent
+               text: "Hello World!"
+           }
+       }
+   }
+   \endqml
+*/
+ApplicationWindow {
+    id: window
+
+    property alias appBar: appBar
+
+    /*!
+       \qmlproperty Page initialPage
+
+       The initial page shown when the application starts.
+     */
+    property alias initialPage: pageStack.initialItem
+
+    /*!
+       \qmlproperty PageStack pageStack
+
+       The \l PageStack used for controlling pages and transitions between pages.
+     */
+    property alias pageStack: pageStack
+
+    header: AppToolBar {
+        id: appBar
+    }
+
+    PageStack {
+        id: pageStack
+
+        width: parent.width
+        height: parent.height
+
+        onPushed: appBar.push(page)
+        onPopped: appBar.pop(page)
+        onReplaced: appBar.replace(page)
+    }
+}

--- a/ui/Icon.qml
+++ b/ui/Icon.qml
@@ -99,11 +99,7 @@ Item {
 
        \sa name
      */
-    property url source: name ? name.indexOf("/") === 0 || name.indexOf("file://") === 0
-                                ? name
-                                : name.indexOf("/") !== -1 ? "icon://" + name
-                                                           : "image://desktoptheme/" + name
-                                : undefined
+     property url source: Utils.getSourceForIconName(name)
 
     /*!
        \qmlproperty enumeration status

--- a/ui/IconButton.qml
+++ b/ui/IconButton.qml
@@ -1,0 +1,28 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Controls.Material 2.0
+
+ToolButton {
+    id: iconButton
+
+    property alias iconName: icon.name
+    property alias iconSource: icon.source
+    property alias iconSize: icon.size
+    property alias iconColor: icon.color
+
+    indicator: Icon {
+        id: icon
+
+        anchors.centerIn: parent
+    }
+}

--- a/ui/Page.qml
+++ b/ui/Page.qml
@@ -1,0 +1,133 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import Fluid.UI 1.0
+
+/*!
+   \qmltype Page
+   \inqmlmodule Fluid.UI 1.0
+
+   \brief Represents a page on the navigation page stack.
+
+   Example:
+
+   \qml
+   import QtQuick 2.4
+   import Fluid.UI 1.0
+
+   Page {
+       title: "Application Name"
+
+       actions: [
+           Action {
+               name: "Print"
+
+               // Icon name from the Google Material Design icon pack
+               iconName: "action/print"
+           }
+       ]
+   }
+   \endqml
+ */
+Page {
+    id: page
+
+    /*
+      \qmlproperty ActionBar actionBar
+
+      The action bar for this page. Use it as a group property to customize
+      this page's action bar. See the \l Page example for details on how to use
+      this property.
+     */
+    property alias appBar: appBar
+
+    /*!
+       The page's actions shown in the action bar.
+     */
+    property alias actions: appBar.actions
+
+    /*!
+       The action shown to the left of the title in the action bar. By default,
+       this is a back button which shows when there is a page behind the current
+       page in the page stack. However, you can replace it with your own action,
+       for example, an icon to open a navigation drawer when on your root page.
+     */
+    property alias leftAction: appBar.leftAction
+
+    /*!
+       \internal
+       Set by the page stack to true if there is a page behind this page on the
+       page stack.
+     */
+    property bool canGoBack: false
+
+    /*!
+       This signal is emitted when the back action is triggered or back key is released.
+
+       By default, the page will be popped from the page stack. To change the default
+       behavior, for example to show a confirmation dialog, listen for this signal using
+       \c onGoBack and set \c event.accepted to \c true. To dismiss the page from your
+       dialog without triggering this signal and re-showing the dialog, call
+       \c page.forcePop().
+     */
+    signal goBack(var event)
+
+    /*!
+       Pop this page from the page stack. This does nothing if this page is not
+       the current page on the page stack.
+
+       Use \c force to avoid calling the \l goBack signal. This is useful if you
+       use the \l goBack signal to show a confirmation dialog, and want to close
+       the page from your dialog without showing the dialog again. You can also
+       use \c forcePop() as a shortcut to this behavior.
+     */
+    function pop(event, force) {
+        if (StackView.view.currentItem !== page)
+            return false
+
+        if (!event)
+            event = {accepted: false}
+
+        if (!force)
+            goBack(event)
+
+        if (event.accepted) {
+            return true
+        } else {
+            return StackView.view.pop()
+        }
+    }
+
+    function forcePop() {
+        pop(null, true)
+    }
+
+    /*!
+       Push the specified component onto the page stack.
+     */
+    function push(component, properties) {
+        return StackView.view.push({item: component, properties: properties});
+    }
+
+    AppBar {
+        id: appBar
+
+        title: page.title
+
+        leftAction: Action {
+            text: "Back"
+            iconName: "navigation/arrow_back"
+            onTriggered: page.pop()
+            visible: page.canGoBack
+        }
+    }
+}

--- a/ui/PageStack.qml
+++ b/ui/PageStack.qml
@@ -1,0 +1,46 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+
+/*!
+   \qmltype PageStack
+   \inqmlmodule Material
+
+   \brief Manages the page stack used for navigation.
+*/
+StackView {
+    id: stackView
+
+    signal pushed(Item page)
+    signal popped(Item page)
+    signal replaced(Item page)
+
+    property int __lastDepth: 0
+    property Item __oldItem: null
+
+    onCurrentItemChanged: {
+        if (stackView.currentItem) {
+            stackView.currentItem.canGoBack = stackView.depth > 1;
+            stackView.currentItem.forceActiveFocus()
+
+            if (__lastDepth > stackView.depth) {
+                popped(stackView.currentItem);
+            } else if (__lastDepth < stackView.depth) {
+                pushed(stackView.currentItem);
+            } else {
+                replaced(stackView.currentItem);
+            }
+        }
+
+        __lastDepth = stackView.depth;
+    }
+}

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -1,7 +1,14 @@
 module Fluid.UI
+Action 1.0 Action.qml
+AppBar 1.0 AppBar.qml
+AppToolBar 1.0 AppToolBar.qml
+FluidWindow 1.0 FluidWindow.qml
 Icon 1.0 Icon.qml
+IconButton 1.0 IconButton.qml
 Loadable 1.0 Loadable.qml
 NoiseBackground 1.0 NoiseBackground.qml
+Page 1.0 Page.qml
+PageStack 1.0 PageStack.qml
 Showable 1.0 Showable.qml
 SmoothFadeImage 1.0 SmoothFadeImage.qml
 SmoothFadeLoader 1.0 SmoothFadeLoader.qml


### PR DESCRIPTION
This brings in an initial basic version of the common application pattern of a page-based app with each page having its own app bar, which can have a left action, a title, and one or more actions on the right.

The goal is to eventually upstream the `AppBar` component, and maybe some other parts of this as well.
